### PR TITLE
Fix the imports in the main mindtouchHttp.js

### DIFF
--- a/src/mindtouchHttp.js
+++ b/src/mindtouchHttp.js
@@ -1,3 +1,3 @@
-import Plug from './plug';
-import Uri from './uri';
+import { Plug } from './plug';
+import { Uri } from './uri';
 export { Plug, Uri };


### PR DESCRIPTION
This is necessary so that this file can be used as the "main" entry, and still export these 2 modules.  The usage would be like:

```import { Plug, Uri } from 'mindtouch-http';```

or 

```
const Plug = require('mindtouch-http').Plug;
const Uri = require('mindtouch-http').Uri;
```