### PR TITLE
Fix the HTTP error code handling to onlt return the status text

### DIFF
--- a/src/plug.js
+++ b/src/plug.js
@@ -22,15 +22,11 @@ function _handleHttpError(response) {
 
         // Throw for all non-2xx status codes, except for 304
         if(!response.ok && response.status !== 304) {
-            Promise.all([
-                response.text(),
-                response.json()
-            ]).then(([ text, json ]) => {
+            response.text().then((text) => {
                 reject({
                     message: response.statusText,
                     status: response.status,
-                    responseText: text,
-                    responseJson: json
+                    responseText: text
                 });
             });
         } else {


### PR DESCRIPTION
The response can't be parsed for json and text in parallel.  The decision was made to only parse out the response text and leave it up to the caller to parse it into JSON if necessary