### PR TITLE
Remove response parsing functionality & add JSPM helper fields

### DIFF
--- a/__tests__/plug.spec.js
+++ b/__tests__/plug.spec.js
@@ -129,6 +129,9 @@ describe('Plug JS', () => {
             pit('can do a basic PUT request', () => {
                 return p.put('{"foo": "BAZ"}', 'application/json');
             });
+            pit('can do a basic PUT request that returns JSON', () => {
+                return p.putJson('{"foo": "BAZ"}', 'application/json');
+            });
             pit('can do a basic DELETE request', () => {
                 return p.delete();
             });

--- a/__tests__/plug.spec.js
+++ b/__tests__/plug.spec.js
@@ -109,12 +109,6 @@ describe('Plug JS', () => {
             pit('can do a basic GET request', () => {
                 return p.get();
             });
-            pit('can do a basic GET request for text', () => {
-                return p.getText();
-            });
-            pit('can do a basic GET request for JSON', () => {
-                return p.getJson();
-            });
             pit('can do a basic HEAD request', () => {
                 return p.head();
             });
@@ -128,9 +122,6 @@ describe('Plug JS', () => {
             });
             pit('can do a basic PUT request', () => {
                 return p.put('{"foo": "BAZ"}', 'application/json');
-            });
-            pit('can do a basic PUT request that returns JSON', () => {
-                return p.putJson('{"foo": "BAZ"}', 'application/json');
             });
             pit('can do a basic DELETE request', () => {
                 return p.delete();

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "description": "A JavaScript library to construct URLs and make HTTP requests using the fetch API",
   "main": "src/mindtouchHttp.js",
+  "format": "esm",
+  "registry": "npm",
   "repository": {
     "type": "git",
     "url": "https://github.com/MindTouch/mindtouch-http.js"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "test-node": "jest --config jest-node.json",
-    "test": "jest --config jest-jsdom.json",
+    "test-jsdom": "jest --config jest-jsdom.json",
+    "test": "npm run test-jsdom & npm run test-node;wait",
     "inspect": "eslint ./**/*.js"
   },
   "author": "MindTouch",

--- a/src/plug.js
+++ b/src/plug.js
@@ -157,8 +157,14 @@ export class Plug {
         let params = this._beforeRequest({ method: method, body: body, headers: _cloneHeaders.call(this) });
         return _doFetch.call(this, params);
     }
+    postJson(body, mime, method) {
+        return this.post(body, mime, method).then((r) => r.json());
+    }
     put(body, mime) {
         return this.post(body, mime, 'PUT');
+    }
+    putJson(body, mime) {
+        return this.postJson(body, mime, 'PUT');
     }
     head() {
         return this.get('HEAD');

--- a/src/plug.js
+++ b/src/plug.js
@@ -146,25 +146,13 @@ export class Plug {
         let params = this._beforeRequest({ method: method, headers: _cloneHeaders.call(this) });
         return _doFetch.call(this, params);
     }
-    getText() {
-        return this.get().then((r) => r.text());
-    }
-    getJson() {
-        return this.get().then((r) => r.json());
-    }
     post(body, mime, method = 'POST') {
         this._headers['Content-Type'] = mime;
         let params = this._beforeRequest({ method: method, body: body, headers: _cloneHeaders.call(this) });
         return _doFetch.call(this, params);
     }
-    postJson(body, mime, method) {
-        return this.post(body, mime, method).then((r) => r.json());
-    }
     put(body, mime) {
         return this.post(body, mime, 'PUT');
-    }
-    putJson(body, mime) {
-        return this.postJson(body, mime, 'PUT');
     }
     head() {
         return this.get('HEAD');


### PR DESCRIPTION
This commit removes the getJson() and getText() functions as it is better for the caller to manipulate the fetch API Response objects directly.

Additionally, a couple of helper "hint" fields were added to help web clients that want to use this in a JSPM environment.