### PR TITLE
MTP-3776: Add optional cookie support to Plug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
-__coverage__/
+__coverage-*__/
 npm-debug.log
 .idea/

--- a/__mocks__/fetch.js
+++ b/__mocks__/fetch.js
@@ -9,8 +9,24 @@ class Headers {
         }
         return this._headers[key];
     }
+    set(key, value) {
+        if(!this._headers) {
+            this._headers = {};
+        }
+        this._headers[key] = value;
+    }
+    getAll() {
+        return [];
+    }
 }
-class Request {}
+class Request {
+    get url() {
+        return 'https://www.example.com';
+    }
+    get headers() {
+        return new Headers();
+    }
+}
 class Response {
     constructor(body = '', init = {}) {
         this._status = init.status || 200;
@@ -20,6 +36,9 @@ class Response {
     }
     get status() {
         return this._status;
+    }
+    get headers() {
+        return new Headers();
     }
     text() {
         return Promise.resolve('');

--- a/__tests__/cookieJar.spec.js
+++ b/__tests__/cookieJar.spec.js
@@ -1,0 +1,19 @@
+/* eslint-env node, jasmine, jest */
+jest.unmock('tough-cookie');
+jest.unmock('../src/cookieJar');
+const cj = require('../src/cookieJar');
+describe('Cookie Jar tests', () => {
+    const cookieUrl = 'https://www.example.com';
+    it('can get all of the cookies', () => {
+        return cj.getCookies(cookieUrl);
+    });
+    it('can get the cookies as a header string', () => {
+        return cj.getCookieString(cookieUrl);
+    });
+    it('can store an array of cookies', () => {
+        return Promise.all([
+            cj.storeCookies(cookieUrl, 'c1=foo'),
+            cj.storeCookies(cookieUrl, [ 'c1=foo', 'c2=bar' ])
+        ]);
+    });
+});

--- a/__tests__/plug.spec.js
+++ b/__tests__/plug.spec.js
@@ -21,7 +21,8 @@ describe('Plug JS', () => {
                 headers: {
                     'X-Deki-Token': 'abcd1234'
                 },
-                timeout: 200
+                timeout: 200,
+                cookieLib: {}
             };
             let p = new Plug('http://www.example.com', params);
             expect(p.url).toBe('http://www.example.com/dog/cat/123?foo=bar&def=456');
@@ -158,6 +159,24 @@ describe('Plug JS', () => {
         });
         pit('can pass with a 304 status', () => {
             global.fetch = jest.genMockFunction().mockReturnValueOnce(Promise.resolve(new Response('', { status: 304 })));
+            return p.get();
+        });
+    });
+    describe('Cookie Jar', () => {
+        jest.unmock('tough-cookie');
+        jest.unmock('../src/cookieJar');
+        let p = null;
+        beforeEach(() => {
+            const cookieJar = require('../src/cookieJar');
+            cookieJar.getCookieString = jest.genMockFunction().mockReturnValueOnce(Promise.resolve('value=this is a cookie value'));
+            global.fetch = jest.genMockFunction().mockReturnValueOnce(Promise.resolve(new Response()));
+            p = new Plug('http://example.com/', { cookieManager: cookieJar });
+        });
+        afterEach(() => {
+            p = null;
+            global.fetch = null;
+        });
+        it('can do requests with a cookie jar in place', () => {
             return p.get();
         });
     });

--- a/jest-jsdom.json
+++ b/jest-jsdom.json
@@ -1,6 +1,6 @@
 {
     "name": "mindtouch-http",
     "verbose": false,
-    "coverageDirectory": "__coverage__",
+    "coverageDirectory": "__coverage-jsdom__",
     "collectCoverage": true
 }

--- a/jest-node.json
+++ b/jest-node.json
@@ -2,6 +2,6 @@
     "name": "mindtouch-http",
     "testEnvironment": "node",
     "verbose": false,
-    "coverageDirectory": "__coverage__",
+    "coverageDirectory": "__coverage-node__",
     "collectCoverage": true
 }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "homepage": "https://github.com/MindTouch/mindtouch-http.js",
   "devDependencies": {
-    "babel-jest": "12.0.2",
-    "babel-preset-es2015": "6.6.0",
-    "eslint": "2.10.1",
+    "babel-jest": "14.1.0",
+    "babel-preset-es2015": "6.13.2",
+    "eslint": "3.3.0",
     "eslint-config-mindtouch": "1.0.0",
-    "jest-cli": "12.0.2"
+    "jest-cli": "14.1.0"
   }
 }

--- a/src/cookieJar.js
+++ b/src/cookieJar.js
@@ -1,0 +1,29 @@
+/* eslint-env node */
+const tough = require('tough-cookie');
+const _cookieJar = new tough.CookieJar();
+module.exports = {
+    getCookies(url) {
+        return new Promise((resolve) => {
+            _cookieJar.getCookies(url, (err, cookies) => {
+                resolve(cookies);
+            });
+        });
+    },
+    getCookieString(url) {
+        return new Promise((resolve) => {
+            _cookieJar.getCookieString(url, (err, cookie) => {
+                resolve(cookie);
+            });
+        });
+    },
+    storeCookies(url, cookies) {
+        if(!Array.isArray(cookies)) {
+            cookies = [ cookies ];
+        }
+        return Promise.all(cookies.map((cookie) => {
+            return new Promise((setResolve) => {
+                _cookieJar.setCookie(cookie, url, () => setResolve());
+            });
+        }));
+    }
+};

--- a/src/globalFetch.js
+++ b/src/globalFetch.js
@@ -1,0 +1,6 @@
+/* eslint-env node, es6 */
+const fetch = require('node-fetch');
+global.fetch = fetch;
+global.Headers = fetch.Headers;
+global.Request = fetch.Request;
+global.Response = fetch.Response;


### PR DESCRIPTION
Ticket: https://mindtouch.myjetbrains.com/youtrack/issue/MTP-3776
Reviewed by @modethirteen & @JeremyRH 

- Add a cookie jar implementation to the repo.
- Add code to Plug to optionally fetch and store cookies before and after the fetch API calls.
- Tests for new implementations
- Split coverage reporting into 2 directories for node and jsdom implementations