### PR TITLE
Fix import paths in Plug subclasses

### DIFF
--- a/lib/progressPlugBrowser.js
+++ b/lib/progressPlugBrowser.js
@@ -1,4 +1,4 @@
-import { Plug } from './plug.js';
+import { Plug } from '../plug.js';
 function _doXhr({ xhr, body, progressInfo }) {
     return new Promise((resolve, reject) => {
         xhr.onreadystatechange = function(e) {

--- a/lib/progressPlugNode.js
+++ b/lib/progressPlugNode.js
@@ -1,2 +1,2 @@
-import { Plug } from './plug.js';
+import { Plug } from '../plug.js';
 export class ProgressPlugNode extends Plug {}


### PR DESCRIPTION
Ticket: https://mindtouch.myjetbrains.com/youtrack/issue/MTP-4377
Reviewed by @JeremyRH 

plug.js moved from src/ to the project root.  These 2 guys need to import it from there.
