### PR TITLE
Use XHR upload to monitor progress

### DIFF
--- a/lib/progressPlugBrowser.js
+++ b/lib/progressPlugBrowser.js
@@ -41,7 +41,7 @@ function _handleCookies(xhr) {
 function _doRequest({ method, headers, body = null, progressInfo }) {
     const xhr = new XMLHttpRequest();  // eslint-disable-line no-undef
     xhr.open(method, this.url, true);
-    xhr.onprogress = (e) => {
+    xhr.upload.onprogress = (e) => {
         progressInfo.callback({ loaded: e.loaded, total: progressInfo.size });
     };
     for(const [ header, val ] of Object.entries(headers)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mindtouch-http",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "A JavaScript library to construct URLs and make HTTP requests using the fetch API",
   "format": "esm",
   "registry": "npm",


### PR DESCRIPTION
Reviewed by @JeremyRH 

The progress plug should listen on XHR.upload.onprogress for file upload progress (not xhr.onprogress)