### PR TITLE
Fix for null and undefined query param values

### DIFF
--- a/__tests__/uri.spec.js
+++ b/__tests__/uri.spec.js
@@ -68,7 +68,8 @@ describe('URI', () => {
             it('can add query parameters', () => {
                 uri.addQueryParam('new', 'param');
                 uri.addQueryParam('new2', 'Bling $$');
-                expect(uri.toString()).toBe('https://www.example.com/foo/bar?dog=cat&llama=goat&new=param&new2=Bling%20%24%24#abcd=1234&defg=5678');
+                uri.addQueryParam('new3', null);
+                expect(uri.toString()).toBe('https://www.example.com/foo/bar?dog=cat&llama=goat&new=param&new2=Bling%20%24%24&new3=#abcd=1234&defg=5678');
             });
             it('can batch-add query params', () => {
                 uri.addQueryParams({ a: '1', b: '2', c: '3' });

--- a/uri.js
+++ b/uri.js
@@ -53,7 +53,8 @@ export class Uri {
         this.parsedUrl.searchParams.delete(key);
     }
     addQueryParam(key, value) {
-        this.parsedUrl.searchParams.append(key, encodeURIComponent(value));
+        const paramVal = value === null || typeof value === 'undefined' ? '' : encodeURIComponent(value);
+        this.parsedUrl.searchParams.append(key, paramVal);
     }
     addQueryParams(queryMap) {
         Object.keys(queryMap).forEach((key) => {


### PR DESCRIPTION
Reviewed by @JeremyRH 

Sending in `null` or `undefined` as a query param value no longer returns `key=null`