### PR TITLE
Enhancements to Plug's fetch integration with cookie jar

### DIFF
--- a/__mocks__/fetch.js
+++ b/__mocks__/fetch.js
@@ -1,35 +1,75 @@
 /* eslint-env node */
 class Headers {
-    constructor(obj) {
-        this._headers = obj;
+    constructor(headers = {}) {
+        this._headers = {};
+        for(let header in headers) {
+            if(headers.hasOwnProperty(header)) {
+                this.set(header, headers[header]);
+            }
+        }
     }
     get(key) {
+        let values = this.getAll(key);
+        return values.length ? values.join(',') : null;
+    }
+    set(key, value) {
+        key = key.toLowerCase();
+        this._headers[key] = this._headers[key] || [];
+        this._headers[key].push(value);
+    }
+    has(key) {
+        return typeof this._headers[key.toLowerCase()] !== 'undefined';
+    }
+    getAll(key) {
+        key = key.toLowerCase();
         if(!(key in this._headers)) {
-            return null;
+            return [];
         }
         return this._headers[key];
     }
-    set(key, value) {
-        if(!this._headers) {
-            this._headers = {};
-        }
-        this._headers[key] = value;
-    }
-    getAll() {
-        return [];
-    }
 }
 class Request {
+    constructor(url = 'https://www.example.com', {
+        method = 'GET',
+        redirect = 'follow',
+        credentials = 'include',
+        headers = new Headers()
+    } = {}) {
+        this._url = url;
+        this._method = method;
+        this._redirect = redirect;
+        this._credentials = credentials;
+        this._headers = headers;
+    }
     get url() {
-        return 'https://www.example.com';
+        return this._url;
+    }
+    get method() {
+        return this._method;
+    }
+    get redirect() {
+        return this._redirect;
+    }
+    get credentials() {
+        return this._credentials;
     }
     get headers() {
-        return new Headers();
+        return this._headers;
     }
 }
 class Response {
-    constructor(body = '', init = {}) {
-        this._status = init.status || 200;
+    constructor(body = '', {
+        status = 200,
+        headers = new Headers(),
+        url = 'https://www.example.com'
+    } = {}) {
+        this._body = body;
+        this._status = status;
+        this._headers = headers;
+        this._url = url;
+    }
+    get url() {
+        return this._url;
     }
     get ok() {
         return this._status >= 200 && this._status < 300;
@@ -37,14 +77,21 @@ class Response {
     get status() {
         return this._status;
     }
+    get statusText() {
+        return '';
+    }
     get headers() {
-        return new Headers();
+        return this._headers;
     }
     text() {
-        return Promise.resolve('');
+        return Promise.resolve(this._body);
     }
     json() {
-        return Promise.resolve({});
+        try {
+            return Promise.resolve(JSON.parse(this._body));
+        } catch(e) {
+            return Promise.reject(e);
+        }
     }
 }
 global.Headers = Headers;

--- a/__tests__/plug.spec.js
+++ b/__tests__/plug.spec.js
@@ -8,11 +8,13 @@ describe('Plug JS', () => {
     });
     describe('constructor', () => {
         it('can construct a Plug with defaults', () => {
-            let p = new Plug();
+            const p = new Plug();
             expect(p.url).toBe('/');
         });
         it('can construct a Plug with all possible params', () => {
-            let params = {
+            const cookieManager = {};
+            const fetchImpl = {};
+            const params = {
                 uriParts: {
                     segments: [ 'dog', 'cat', 123 ],
                     query: { foo: 'bar', abc: 123, def: 456 },
@@ -22,13 +24,58 @@ describe('Plug JS', () => {
                     'X-Deki-Token': 'abcd1234'
                 },
                 timeout: 200,
-                cookieLib: {}
+                cookieManager,
+                fetchImpl,
+                followRedirects: false
             };
-            let p = new Plug('http://www.example.com', params);
+            const p = new Plug('http://www.example.com', params);
             expect(p.url).toBe('http://www.example.com/dog/cat/123?foo=bar&def=456');
-            let h = p.headers;
+            const h = p.headers;
             expect(h instanceof Headers).toBe(true);
             expect(h.get('X-Deki-Token')).toBe('abcd1234');
+            expect(p._followRedirects).toBe(false);
+            expect(p._cookieManager).toBe(cookieManager);
+            expect(p._fetch).toBe(fetchImpl);
+        });
+        it('maintains params between Plug constructors', () => {
+            const cookieManager = {};
+            const fetchImpl = {};
+            const params = {
+                uriParts: {
+                    segments: [ 'dog', 'cat', 123 ],
+                    query: { foo: 'bar', abc: 123, def: 456 },
+                    excludeQuery: 'abc'
+                },
+                headers: {
+                    'X-Deki-Token': 'abcd1234'
+                },
+                timeout: 200,
+                cookieManager,
+                fetchImpl,
+                followRedirects: false
+            };
+            const p = new Plug('http://www.example.com', params).at('qux')
+                .withParam('foo', 'bar')
+                .withParams({
+                    qux: 'fred'
+                })
+                .withoutParam('foo')
+                .withHeader('X-Devo', 'Whip it')
+                .withHeaders({
+                    'X-Aphex-Twin': 'Come to Daddy'
+                })
+                .withoutHeader('X-Devo')
+                .withFollowRedirects()
+                .withoutFollowRedirects();
+            expect(p.url).toBe('http://www.example.com/dog/cat/123/qux?def=456&qux=fred');
+            const h = p.headers;
+            expect(h instanceof Headers).toBe(true);
+            expect(h.get('X-Deki-Token')).toBe('abcd1234');
+            expect(h.get('X-Devo')).toBe(null);
+            expect(h.get('X-Aphex-Twin')).toBe('Come to Daddy');
+            expect(p._followRedirects).toBe(false);
+            expect(p._cookieManager).toBe(cookieManager);
+            expect(p._fetch).toBe(fetchImpl);
         });
     });
     describe('whatwg/fetch implementation', () => {
@@ -51,6 +98,30 @@ describe('Plug JS', () => {
                 expect(fetchMock).toBeCalled();
             });
         });
+        it('is maintained between plug constructors and fetch invocation', () => {
+            const fetchMock = jest.genMockFunction().mockReturnValueOnce(Promise.resolve(new Response()));
+            const plug = new Plug('http://example.com', {
+                fetchImpl: fetchMock
+            });
+            return plug.at('qux')
+                .withParam('foo', 'bar')
+                .withParams({
+                    qux: 'fred'
+                })
+                .withoutParam('foo')
+                .withHeader('X-Devo', 'Whip it')
+                .withHeaders({
+                    'X-Aphex-Twin': 'Come to Daddy'
+                })
+                .withoutHeader('X-Devo')
+                .withFollowRedirects()
+                .withoutFollowRedirects()
+                .get()
+                .then(() => {
+                    expect(global.fetch).not.toBeCalled();
+                    expect(fetchMock).toBeCalled();
+                });
+        });
     });
     describe('URI construction', () => {
         let plug = null;
@@ -61,27 +132,27 @@ describe('Plug JS', () => {
             plug = null;
         });
         it('can add segments', () => {
-            let p2 = plug.at('@api', 'foo', 'bar');
+            const p2 = plug.at('@api', 'foo', 'bar');
             expect(p2.url).toBe('http://www.example.com/@api/foo/bar');
             expect(plug.url).toBe('http://www.example.com/');
         });
         it('can add no query params', () => {
-            let newPlug = plug.withParams();
+            const newPlug = plug.withParams();
             expect(newPlug.url).toBe('http://www.example.com/');
             expect(plug.url).toBe('http://www.example.com/');
         });
         it('can add a single query param', () => {
-            let newPlug = plug.withParam('dog', 123);
+            const newPlug = plug.withParam('dog', 123);
             expect(newPlug.url).toBe('http://www.example.com/?dog=123');
             expect(plug.url).toBe('http://www.example.com/');
         });
         it('can add multiple query params', () => {
-            let newPlug = plug.withParams({ dog: 123, cat: 'def' });
+            const newPlug = plug.withParams({ dog: 123, cat: 'def' });
             expect(newPlug.url).toBe('http://www.example.com/?dog=123&cat=def');
             expect(plug.url).toBe('http://www.example.com/');
         });
         it('can remove query params', () => {
-            let newPlug = plug.withParams({ dog: 123, cat: 'def' }).withoutParam('dog');
+            const newPlug = plug.withParams({ dog: 123, cat: 'def' }).withoutParam('dog');
             expect(newPlug.url).toBe('http://www.example.com/?cat=def');
             expect(plug.url).toBe('http://www.example.com/');
         });
@@ -95,7 +166,7 @@ describe('Plug JS', () => {
             plug = null;
         });
         it('can add a single header', () => {
-            let newPlug = plug.withHeader('Content-Type', 'application/json');
+            const newPlug = plug.withHeader('Content-Type', 'application/json');
             expect(newPlug.headers.get('Content-Type')).toBe('application/json');
             expect(plug.headers.get('Content-Type')).toBeNull();
         });
@@ -109,7 +180,7 @@ describe('Plug JS', () => {
             expect(plug.headers.get('Content-Type')).toBeNull();
         });
         it('can remove headers', () => {
-            let newPlug = plug.withHeaders({
+            const newPlug = plug.withHeaders({
                 'Content-Type': 'application/json',
                 'X-Deki-Token': 'abcd1234'
             }).withoutHeader('Content-Type');
@@ -178,86 +249,118 @@ describe('Plug JS', () => {
             return p.get();
         });
     });
+    describe('Not Following Redirects', () => {
+        it('can disable follow redirects', () => {
+            let p = new Plug('http://example.com', {
+                followRedirects: true
+            });
+            p = p.withoutFollowRedirects();
+            expect(p._followRedirects).toBe(false);
+        });
+        for(let status of [ 301, 302, 303, 307, 308 ]) {
+            it(`can fail a ${status} status without location header`, () => {
+                global.fetch = jest.genMockFunction();
+                global.fetch.mockReturnValueOnce(Promise.resolve(new Response('', { status })));
+                const p = new Plug('http://example.com', {
+                    followRedirects: false
+                });
+                return p.get().catch((e) => expect(e).toBeDefined());
+            });
+            it(`can allow a ${status} status with location header`, () => {
+                global.fetch = jest.genMockFunction();
+                global.fetch.mockReturnValueOnce(Promise.resolve(new Response('', {
+                    status,
+                    headers: new Headers({
+                        location: 'https://bar.foo.com'
+                    })
+                })));
+                const p = new Plug('http://example.com', {
+                    followRedirects: false
+                });
+                return p.get();
+            });
+        }
+    });
     describe('Following Redirects', () => {
-        it('can fail if not following redirects and HTTP 3xx without location header', () => {
-            global.fetch = jest.genMockFunction();
-            global.fetch.mockReturnValueOnce(Promise.resolve(new Response('', { status: 302 })));
-            const p = new Plug('http://example.com', {
+        it('can enable follow redirects', () => {
+            let p = new Plug('http://example.com', {
                 followRedirects: false
             });
-            return p.get().catch((e) => expect(e).toBeDefined());
+            p = p.withFollowRedirects();
+            expect(p._followRedirects).toBe(true);
         });
-        it('can allow a HTTP 301 redirect with location header if not following redirects', () => {
-            global.fetch = jest.genMockFunction();
-            global.fetch.mockReturnValueOnce(Promise.resolve(new Response('', {
-                status: 301,
-                headers: new Headers({
-                    location: 'https://bar.foo.com'
-                })
-            })));
-            const p = new Plug('http://example.com', {
-                followRedirects: false
+        for(let status of [ 301, 302, 303 ]) {
+            it(`can follow a ${status} status GET redirect and set cookie`, () => {
+                global.fetch = jest.genMockFunction();
+                const url = 'http://example.com/';
+                const location = 'https://bar.foo.com'; 
+                const redirect = new Response('', {
+                    url,
+                    status,
+                    headers: new Headers({
+                        location,
+                        'set-cookie': 'authtoken="123"'
+                    })
+                });
+                global.fetch.mockReturnValueOnce(Promise.resolve(redirect));
+                const resolved = new Response();
+                global.fetch.mockReturnValueOnce(Promise.resolve(resolved));
+                const cookieManager = require('../lib/cookieJar');
+                const p = new Plug(url, {
+                    followRedirects: true,
+                    cookieManager
+                });
+                return p.post().then((r) => {
+                    expect(global.fetch.mock.calls.length).toBe(2);
+                    const request1 = global.fetch.mock.calls[0][0];
+                    expect(request1.method).toBe('POST');
+                    expect(request1.url).toBe(url);
+                    const request2 = global.fetch.mock.calls[1][0];
+                    expect(request2.method).toBe('GET');
+                    expect(request2.url).toBe(location);
+                    expect(r).toBe(resolved);
+                    return cookieManager.getCookieString(url);
+                }).then((cookie) => {
+                    expect(cookie).toBe('authtoken="123"');
+                });
             });
-            return p.get();
-        });
-        it('can follow a HTTP 302 redirect with location header if not following redirects', () => {
-            global.fetch = jest.genMockFunction();
-            global.fetch.mockReturnValueOnce(Promise.resolve(new Response('', {
-                status: 302,
-                headers: new Headers({
-                    location: 'https://bar.foo.com'
-                })
-            })));
-            const p = new Plug('http://example.com', {
-                followRedirects: false
+        }
+        for(let status of [ 307, 308 ]) {
+            it(`can follow a ${status} status POST redirect and set cookie`, () => {
+                global.fetch = jest.genMockFunction();
+                const url = 'http://example.com/';
+                const location = 'https://bar.foo.com'; 
+                const redirect = new Response('', {
+                    url,
+                    status,
+                    headers: new Headers({
+                        location,
+                        'set-cookie': 'authtoken="123"'
+                    })
+                });
+                global.fetch.mockReturnValueOnce(Promise.resolve(redirect));
+                const resolved = new Response();
+                global.fetch.mockReturnValueOnce(Promise.resolve(resolved));
+                const cookieManager = require('../lib/cookieJar');
+                const p = new Plug(url, {
+                    followRedirects: true,
+                    cookieManager
+                });
+                return p.post().then((r) => {
+                    expect(global.fetch.mock.calls.length).toBe(2);
+                    const request1 = global.fetch.mock.calls[0][0];
+                    expect(request1.method).toBe('POST');
+                    expect(request1.url).toBe(url);
+                    const request2 = global.fetch.mock.calls[1][0];
+                    expect(request2.method).toBe('POST');
+                    expect(request2.url).toBe(location);
+                    expect(r).toBe(resolved);
+                    return cookieManager.getCookieString(url);
+                }).then((cookie) => {
+                    expect(cookie).toBe('authtoken="123"');
+                });
             });
-            return p.get();
-        });
-        it('can follow a HTTP 303 redirect with location header if not following redirects', () => {
-            global.fetch = jest.genMockFunction();
-            global.fetch.mockReturnValueOnce(Promise.resolve(new Response('', {
-                status: 303,
-                headers: new Headers({
-                    location: 'https://bar.foo.com'
-                })
-            })));
-            const p = new Plug('http://example.com', {
-                followRedirects: false
-            });
-            return p.get();
-        });
-        it('can follow a redirect and set cookie', () => {
-            global.fetch = jest.genMockFunction();
-            const url = 'http://example.com/';
-            const location = 'https://bar.foo.com'; 
-            const redirect = new Response('', {
-                url,
-                status: 302,
-                headers: new Headers({
-                    location,
-                    'set-cookie': 'authtoken="123"'
-                })
-            });
-            global.fetch.mockReturnValueOnce(Promise.resolve(redirect));
-            const resolved = new Response();
-            global.fetch.mockReturnValueOnce(Promise.resolve(resolved));
-            const cookieManager = require('../lib/cookieJar');
-            const p = new Plug(url, {
-                followRedirects: true,
-                cookieManager
-            });
-            return p.get().then((r) => {
-                expect(global.fetch.mock.calls.length).toBe(2);
-                const request1 = global.fetch.mock.calls[0][0];
-                expect(request1.url).toBe(url);
-                const request2 = global.fetch.mock.calls[1][0];
-                expect(request2.url).toBe(location);
-                expect(r).toBe(resolved);
-                return cookieManager.getCookieString(url);
-            }).then((cookie) => {
-                expect(cookie).toBe('authtoken="123"');
-            });
-        });
+        }
     });
     describe('Cookie Jar', () => {
         let p = null;

--- a/__tests__/plug.spec.js
+++ b/__tests__/plug.spec.js
@@ -293,7 +293,7 @@ describe('Plug JS', () => {
             it(`can follow a ${status} status GET redirect and set cookie`, () => {
                 global.fetch = jest.genMockFunction();
                 const url = 'http://example.com/';
-                const location = 'https://bar.foo.com'; 
+                const location = 'https://bar.foo.com';
                 const redirect = new Response('', {
                     url,
                     status,
@@ -329,7 +329,7 @@ describe('Plug JS', () => {
             it(`can follow a ${status} status POST redirect and set cookie`, () => {
                 global.fetch = jest.genMockFunction();
                 const url = 'http://example.com/';
-                const location = 'https://bar.foo.com'; 
+                const location = 'https://bar.foo.com';
                 const redirect = new Response('', {
                     url,
                     status,

--- a/dist/index.js
+++ b/dist/index.js
@@ -467,7 +467,7 @@ function _handleHttpError(response) {
         }
 
         // throw for all non-2xx status codes, except for 304
-        if((!response.ok && response.status !== 304)) {
+        if(!response.ok && response.status !== 304) {
             response.text().then((text) => {
                 reject({
                     message: response.statusText,

--- a/dist/index.js
+++ b/dist/index.js
@@ -243,7 +243,7 @@ class UriParser {
 }
 
 /**
- * Martian - Core JavaScript API for MindTouch
+ * mindtouch-http.js - A JavaScript library to construct URLs and make HTTP requests using the fetch API
  *
  * Copyright (c) 2015 MindTouch Inc.
  * www.mindtouch.com  oss@mindtouch.com
@@ -426,7 +426,7 @@ class Uri {
 }
 
 /**
- * Martian - Core JavaScript API for MindTouch
+ * mindtouch-http.js - A JavaScript library to construct URLs and make HTTP requests using the fetch API
  *
  * Copyright (c) 2015 MindTouch Inc.
  * www.mindtouch.com  oss@mindtouch.com
@@ -443,6 +443,13 @@ class Uri {
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+function _isRedirectResponse(response) {
+    if(!response.headers.has('location')) {
+        return false;
+    }
+    const code = response.status;
+    return code === 301 || code === 302 || code === 303 || code === 307 || code === 308;
+}
 function _handleHttpError(response) {
     return new Promise((resolve, reject) => {
 
@@ -470,20 +477,42 @@ function _readCookies(request) {
     }
     return Promise.resolve(request);
 }
-function _handleCookies(response) {
+function _handleCookies(request, response) {
     if(this._cookieManager !== null) {
-        return this._cookieManager.storeCookies(response.url, response.headers.getAll('Set-Cookie')).then(() => response);
+        const promise = this._cookieManager.storeCookies(response.url, response.headers.getAll('Set-Cookie')).then(() => response);
+        if(this._followRedirects && _isRedirectResponse(response)) {
+
+            // follow redirect after handling set-cookie HTTP header
+            // eslint-disable-next-line no-use-before-define
+            promise.then(_doFetch.call(this, {
+
+                // only HTTP 301, HTTP 302, and HTTP 303 redirects change HTTP method to GET
+                method: (response.status !== 307 && response.status !== 308) ? 'GET' : request.method,
+                headers: request.headers,
+                body: request.body
+            }));
+        }
+        return promise;
     }
     return Promise.resolve(response);
 }
 function _doFetch({ method, headers, body = null }) {
-    let requestHeaders = new Headers(headers);
-    let requestData = { method: method, headers: requestHeaders, credentials: 'include' };
+    const requestData = {
+        method: method,
+        headers: new Headers(headers),
+        credentials: 'include',
+        redirect: this._followRedirects && this._cookieManager === null ? 'follow' : 'manual'
+    };
     if(body !== null) {
         requestData.body = body;
     }
-    let request = new Request(this._url.toString(), requestData);
-    return _readCookies.call(this, request).then(fetch).then(_handleHttpError).then(_handleCookies.bind(this));
+    const request = new Request(this._url.toString(), requestData);
+    return _readCookies.call(this, request)
+        .then(this._fetch)
+        .then(_handleHttpError)
+
+        // cookie manager needs request in the event it must resolve a redirect
+        .then((response) => _handleCookies.bind(this, request, response));
 }
 
 /**
@@ -492,7 +521,6 @@ function _doFetch({ method, headers, body = null }) {
 class Plug {
 
     /**
-     *
      * @param {String} [url=/] The initial URL to start the URL building from and to ultimately send HTTP requests to.
      * @param {Object} [options] Options to direct the construction of the Plug.
      * @param {Object} [options.uriParts] An object representation of additional URI construction parameters.
@@ -503,8 +531,18 @@ class Plug {
      * @param {Number} [options.timeout=null] The time, in milliseconds, to wait before an HTTP timeout.
      * @param {function} [options.beforeRequest] A function that is called before each HTTP request that allows per-request manipulation of the request headers and query parameters.
      * @param {Object} [options.cookieManager] An object that implements a cookie management interface. This should provide implementations for the `getCookieString()` and `storeCookies()` functions.
+     * @param {Boolean} [options.followRedirects] Should HTTP redirects be auto-followed, or should HTTP redirect responses be returned to the caller (default: true)
+     * @param {function} [options.fetchImpl] whatwg/fetch implementation (default: window.fetch)
      */
-    constructor(url = '/', { uriParts = {}, headers = {}, timeout = null, beforeRequest = (params) => params, cookieManager = null } = {}) {
+    constructor(url = '/', {
+        uriParts = {},
+        headers = {},
+        timeout = null,
+        beforeRequest = (params) => params,
+        cookieManager = null,
+        followRedirects = true,
+        fetchImpl = fetch
+    } = {}) {
 
         // Initialize the url for this instance
         this._url = new Uri(url);
@@ -517,11 +555,12 @@ class Plug {
         if('excludeQuery' in uriParts) {
             this._url.removeQueryParam(uriParts.excludeQuery);
         }
-
         this._beforeRequest = beforeRequest;
         this._timeout = timeout;
         this._headers = headers;
         this._cookieManager = cookieManager;
+        this._followRedirects = followRedirects;
+        this._fetch = fetchImpl;
     }
 
     /**
@@ -628,7 +667,7 @@ class Plug {
      * @returns {Plug} A new Plug instance with the headers included.
      */
     withHeaders(values) {
-        let newHeaders = Object.assign({}, this._headers);
+        const newHeaders = Object.assign({}, this._headers);
         Object.keys(values).forEach((key) => {
             newHeaders[key] = values[key];
         });
@@ -646,7 +685,7 @@ class Plug {
      * @returns {Plug} A new Plug instance with the header excluded.
      */
     withoutHeader(key) {
-        let newHeaders = Object.assign({}, this._headers);
+        const newHeaders = Object.assign({}, this._headers);
         delete newHeaders[key];
         return new this.constructor(this._url.toString(), {
             timeout: this._timeout,
@@ -662,7 +701,7 @@ class Plug {
      * @returns {Promise} A Promise that, when resolved, yields the {Response} object as defined by the fetch API.
      */
     get(method = 'GET') {
-        let params = this._beforeRequest({ method: method, headers: Object.assign({}, this._headers) });
+        const params = this._beforeRequest({ method: method, headers: Object.assign({}, this._headers) });
         return _doFetch.call(this, params);
     }
 
@@ -677,7 +716,7 @@ class Plug {
         if(mime) {
             this._headers['Content-Type'] = mime;
         }
-        let params = this._beforeRequest({ method: method, body: body, headers: Object.assign({}, this._headers) });
+        const params = this._beforeRequest({ method: method, body: body, headers: Object.assign({}, this._headers) });
         return _doFetch.call(this, params);
     }
 

--- a/plug.js
+++ b/plug.js
@@ -41,7 +41,7 @@ function _handleHttpError(response) {
         }
 
         // throw for all non-2xx status codes, except for 304
-        if((!response.ok && response.status !== 304)) {
+        if(!response.ok && response.status !== 304) {
             response.text().then((text) => {
                 reject({
                     message: response.statusText,

--- a/plug.js
+++ b/plug.js
@@ -174,7 +174,7 @@ export class Plug {
      * @returns {Plug} The Plug with the segments included.
      */
     at(...segments) {
-        var values = [];
+        const values = [];
         segments.forEach((segment) => {
             values.push(segment.toString());
         });
@@ -183,7 +183,9 @@ export class Plug {
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             uriParts: { segments: values },
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            followRedirects: this._followRedirects,
+            fetchImpl: this._fetch
         });
     }
 
@@ -194,14 +196,16 @@ export class Plug {
      * @returns {Plug} A new Plug instance with the query parameter included.
      */
     withParam(key, value) {
-        let params = {};
+        const params = {};
         params[key] = value;
         return new this.constructor(this._url.toString(), {
             headers: this._headers,
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             uriParts: { query: params },
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            followRedirects: this._followRedirects,
+            fetchImpl: this._fetch
         });
     }
 
@@ -216,7 +220,9 @@ export class Plug {
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             uriParts: { query: values },
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            followRedirects: this._followRedirects,
+            fetchImpl: this._fetch
         });
     }
 
@@ -231,7 +237,9 @@ export class Plug {
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             uriParts: { excludeQuery: key },
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            followRedirects: this._followRedirects,
+            fetchImpl: this._fetch
         });
     }
 
@@ -242,13 +250,15 @@ export class Plug {
      * @returns {Plug} A new Plug instance with the header included.
      */
     withHeader(key, value) {
-        let newHeaders = Object.assign({}, this._headers);
+        const newHeaders = Object.assign({}, this._headers);
         newHeaders[key] = value;
         return new this.constructor(this._url.toString(), {
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             headers: newHeaders,
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            followRedirects: this._followRedirects,
+            fetchImpl: this._fetch
         });
     }
 
@@ -266,7 +276,9 @@ export class Plug {
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             headers: newHeaders,
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            followRedirects: this._followRedirects,
+            fetchImpl: this._fetch
         });
     }
 
@@ -282,7 +294,38 @@ export class Plug {
             timeout: this._timeout,
             beforeRequest: this._beforeRequest,
             headers: newHeaders,
-            cookieManager: this._cookieManager
+            cookieManager: this._cookieManager,
+            fetchImpl: this._fetch
+        });
+    }
+
+    /**
+     * Get a new Plug, based on the current one, with follow redirects enabled
+     * @returns {Plug} A new Plug instance with follow redirects enabled
+     */
+    withFollowRedirects() {
+        return new this.constructor(this._url.toString(), {
+            timeout: this._timeout,
+            beforeRequest: this._beforeRequest,
+            headers: this._headers,
+            cookieManager: this._cookieManager,
+            followRedirects: true,
+            fetchImpl: this._fetch
+        });
+    }
+
+    /**
+     * Get a new Plug, based on the current one, with follow redirects disabled
+     * @returns {Plug} A new Plug instance with follow redirects disabled
+     */
+    withoutFollowRedirects() {
+        return new this.constructor(this._url.toString(), {
+            timeout: this._timeout,
+            beforeRequest: this._beforeRequest,
+            headers: this._headers,
+            cookieManager: this._cookieManager,
+            followRedirects: false,
+            fetchImpl: this._fetch
         });
     }
 

--- a/progressPlug.js
+++ b/progressPlug.js
@@ -1,3 +1,21 @@
+/**
+ * mindtouch-http.js - A JavaScript library to construct URLs and make HTTP requests using the fetch API
+ *
+ * Copyright (c) 2015 MindTouch Inc.
+ * www.mindtouch.com  oss@mindtouch.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { Plug } from './plug.js';
 function _doXhr({ xhr, body, progressInfo }) {
     return new Promise((resolve, reject) => {

--- a/uri.js
+++ b/uri.js
@@ -1,5 +1,5 @@
 /**
- * Martian - Core JavaScript API for MindTouch
+ * mindtouch-http.js - A JavaScript library to construct URLs and make HTTP requests using the fetch API
  *
  * Copyright (c) 2015 MindTouch Inc.
  * www.mindtouch.com  oss@mindtouch.com


### PR DESCRIPTION
* Allow `whatwg/fetch` implementation to be injected and sandboxed (defaulting to `window.fetch`)
* Enable/disable auto following redirects at `Plug` construction
* Future-proof `Headers.get(...)` and `Headers.getAll(...)` (see https://developer.mozilla.org/en-US/docs/Web/API/Headers/getAll)
* allow cookie jar to receive set-cookies when following redirects
* allow 3xx redirect responses to be resolved if following redirects is disabled